### PR TITLE
Normalise gltf quaternions

### DIFF
--- a/src/gltf/writer.ts
+++ b/src/gltf/writer.ts
@@ -323,7 +323,7 @@ export class Writer {
                     }
                     if (fragment.transform.rotation) {
                         const r = fragment.transform.rotation;
-                        node.rotation = [r.x, r.y, r.z, r.w];
+                        node.rotation = this.normalizeQuaternion(r);
                     }
                     if (fragment.transform.translation) {
                         const t = fragment.transform.translation;
@@ -752,5 +752,17 @@ export class Writer {
             min[2] = Math.min(min[2], array[i + 2]); max[2] = Math.max(max[2], array[i + 2]);
         }
         return { min, max };
+    }
+
+    protected normalizeQuaternion(quaternion: IMF.IQuaternion): number[] {
+        const x = quaternion.x;
+        const y = quaternion.y;
+        const z = quaternion.z;
+        const w = quaternion.w;
+        const len = Math.sqrt(x * x + y * y + z * z + w * w);
+        if (len === 0) {
+            return [0, 0, 0, 1];
+        }
+        return [x / len, y / len, z / len, w / len];
     }
 }

--- a/src/gltf/writer.ts
+++ b/src/gltf/writer.ts
@@ -759,10 +759,11 @@ export class Writer {
         const y = quaternion.y;
         const z = quaternion.z;
         const w = quaternion.w;
-        const len = Math.sqrt(x * x + y * y + z * z + w * w);
-        if (len === 0) {
-            return [0, 0, 0, 1];
+    
+        let len = x * x + y * y + z * z + w * w;
+        if (len > 0) {
+          len = 1 / Math.sqrt(len);
         }
-        return [x / len, y / len, z / len, w / len];
+         return   [x * len,  y * len, z * len, w * len]
     }
 }


### PR DESCRIPTION
Normalise Node rotation quaternions per the GlTF spec. 

We noticed some converted files where invalid when run against the [gltf-Validator](https://github.khronos.org/glTF-Validator/). The error message:
```json
  "code": "ROTATION_NON_UNIT",
  "message": "Rotation quaternion must be normalized."
```

Added a normalise function similar to `gl-matrix` which solves the problem. 